### PR TITLE
Fix: Error in using grid search file

### DIFF
--- a/src/search/grid.js
+++ b/src/search/grid.js
@@ -112,7 +112,7 @@ export const gridSearch = (newIds, domain, trials) => {
   let rval = [];
   const gs = new GridSearch();
   newIds.forEach((newId) => {
-    const paramsEval = gs.eval(domain.expr);
+    const paramsEval = gs.eval(domain.expr, {rng: undefined});
     const result = domain.newResult();
     rval = [...rval, ...trials.newTrialDocs([newId], [result], [paramsEval])];
   });


### PR DESCRIPTION
TypeError: Cannot read property 'rng' of undefined
    at GridSearch.BaseSpace.eval (/mnt/c/Users/sony/Downloads/pics/projects/refuture/node_modules/hyperparameters/lib/hyperparameters.js:282:23)      
    at /mnt/c/Users/sony/Downloads/pics/projects/refuture/node_modules/hyperparameters/lib/hyperparameters.js:1093:25
    at Array.forEach (<anonymous>)
    at gridSearch (/mnt/c/Users/sony/Downloads/pics/projects/refuture/node_modules/hyperparameters/lib/hyperparameters.js:1092:10)
    at FMinIter.<anonymous> (/mnt/c/Users/sony/Downloads/pics/projects/refuture/node_modules/hyperparameters/lib/hyperparameters.js:679:28)
    at Generator.next (<anonymous>)
    at step (/mnt/c/Users/sony/Downloads/pics/projects/refuture/node_modules/hyperparameters/lib/hyperparameters.js:17:30)
    at /mnt/c/Users/sony/Downloads/pics/projects/refuture/node_modules/hyperparameters/lib/hyperparameters.js:35:14
    at new Promise (<anonymous>)
    at FMinIter.<anonymous> (/mnt/c/Users/sony/Downloads/pics/projects/refuture/node_modules/hyperparameters/lib/hyperparameters.js:14:12)
    at FMinIter.run (/mnt/c/Users/sony/Downloads/pics/projects/refuture/node_modules/hyperparameters/lib/hyperparameters.js:704:20)
    at FMinIter.<anonymous> (/mnt/c/Users/sony/Downloads/pics/projects/refuture/node_modules/hyperparameters/lib/hyperparameters.js:710:17)
    at Generator.next (<anonymous>)
    at step (/mnt/c/Users/sony/Downloads/pics/projects/refuture/node_modules/hyperparameters/lib/hyperparameters.js:17:30)
    at /mnt/c/Users/sony/Downloads/pics/projects/refuture/node_modules/hyperparameters/lib/hyperparameters.js:35:14
    at new Promise (<anonymous>)